### PR TITLE
added variable lines to tail in node-red-log

### DIFF
--- a/resources/node-red-log
+++ b/resources/node-red-log
@@ -1,4 +1,13 @@
 #!/bin/bash
+LINES=25
+while getopts ":n:" opt; do
+  case $opt in
+    n) LINES="$OPTARG"
+    ;;
+    \?) echo "Unrecognized option -$OPTARG. Usage: node-red-log [-n lines]. For example: node-red-log -n 50" >&2 && exit 1
+    ;;
+  esac
+done
 echo -e '\033]2;'Node-RED log'\007'
 echo " "
-sudo journalctl -f -n 25 -u nodered -o cat
+sudo journalctl -f -n $LINES -u nodered -o cat


### PR DESCRIPTION
Added argument `-n` to `node-red-log` to specify how many lines of log you want to tail. Default is 25. Example usage: `node-red-log -n 100`.

This is useful for example when you want to troubleshoot an error that already happened, possibly outside the scope of the previously-hardcoded 25 magic number.